### PR TITLE
View and manage wishlist items

### DIFF
--- a/supabase/migrations/20250525120000_create_wishlist_items.sql
+++ b/supabase/migrations/20250525120000_create_wishlist_items.sql
@@ -1,0 +1,22 @@
+-- Create wishlist_items table for storing user wishlist entries
+-- Matches DbWishlistItem type in webapp/src/lib/supabase.ts
+
+create table if not exists wishlist_items (
+  id          uuid primary key default gen_random_uuid(),
+  description text not null,
+  status      text not null default 'want'
+                check (status in ('want', 'purchased', 'packed')),
+  created_at  timestamptz not null default now()
+);
+
+-- Index for ordering by created_at descending (most recent first)
+create index if not exists wishlist_items_created_at_idx
+  on wishlist_items (created_at desc);
+
+-- Enable Row Level Security (open for now — auth can be added later)
+alter table wishlist_items enable row level security;
+
+-- Allow all operations for authenticated and anonymous users
+-- (tighten with user-scoped policies when auth is wired up)
+create policy "allow_all" on wishlist_items
+  for all using (true) with check (true);

--- a/webapp/.npmrc
+++ b/webapp/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+only-built-dependencies[]=esbuild

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -9,15 +9,23 @@
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "vitest run"
 	},
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^7.0.0",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@testing-library/jest-dom": "^6.9.1",
+		"@testing-library/svelte": "^5.3.1",
+		"jsdom": "^28.1.0",
 		"svelte": "^5.51.0",
 		"svelte-check": "^4.3.6",
 		"typescript": "^5.9.3",
-		"vite": "^7.3.1"
+		"vite": "^7.3.1",
+		"vitest": "^4.0.18"
+	},
+	"dependencies": {
+		"@supabase/supabase-js": "^2.97.0"
 	}
 }

--- a/webapp/src/lib/supabase.ts
+++ b/webapp/src/lib/supabase.ts
@@ -1,0 +1,10 @@
+import { createClient } from '@supabase/supabase-js';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY } from '$env/static/public';
+
+export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY);
+
+export type DbWishlistItem = {
+	id: string;
+	description: string;
+	created_at: string;
+};

--- a/webapp/src/lib/supabase.ts
+++ b/webapp/src/lib/supabase.ts
@@ -6,5 +6,6 @@ export const supabase = createClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_PUBLIS
 export type DbWishlistItem = {
 	id: string;
 	description: string;
+	status: 'want' | 'purchased' | 'packed';
 	created_at: string;
 };

--- a/webapp/src/lib/wishlist.test.ts
+++ b/webapp/src/lib/wishlist.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { parseWishlistItem, type WishlistItem } from './wishlist.js';
+
+describe('parseWishlistItem', () => {
+	it('parses a simple item description', () => {
+		const item = parseWishlistItem('Cast iron skillet');
+		expect(item.name).toBe('Cast iron skillet');
+		expect(item.description).toBe('Cast iron skillet');
+		expect(item.status).toBe('want');
+	});
+
+	it('assigns a generated id', () => {
+		const item = parseWishlistItem('Vitamins');
+		expect(item.id).toBeTruthy();
+		expect(typeof item.id).toBe('string');
+	});
+
+	it('sets created_at timestamp', () => {
+		const before = Date.now();
+		const item = parseWishlistItem('Protein bars');
+		const after = Date.now();
+		expect(item.created_at).toBeGreaterThanOrEqual(before);
+		expect(item.created_at).toBeLessThanOrEqual(after);
+	});
+
+	it('uses first sentence as name when description has multiple sentences', () => {
+		const item = parseWishlistItem('Running shoes. For the gym. Size 10.');
+		expect(item.name).toBe('Running shoes');
+		expect(item.description).toBe('Running shoes. For the gym. Size 10.');
+	});
+
+	it('trims whitespace from description', () => {
+		const item = parseWishlistItem('  Hot sauce  ');
+		expect(item.name).toBe('Hot sauce');
+		expect(item.description).toBe('Hot sauce');
+	});
+
+	it('truncates name to 60 chars when first sentence is very long', () => {
+		const long = 'A'.repeat(80);
+		const item = parseWishlistItem(long);
+		expect(item.name.length).toBe(60);
+	});
+
+	it('throws when description is empty', () => {
+		expect(() => parseWishlistItem('')).toThrow('Description cannot be empty');
+		expect(() => parseWishlistItem('   ')).toThrow('Description cannot be empty');
+	});
+});
+
+describe('WishlistItem type', () => {
+	it('has the expected shape', () => {
+		const item: WishlistItem = {
+			id: 'abc123',
+			name: 'Vitamins',
+			description: 'Vitamins',
+			status: 'want',
+			created_at: Date.now()
+		};
+		expect(item.status).toBe('want');
+	});
+});

--- a/webapp/src/lib/wishlist.ts
+++ b/webapp/src/lib/wishlist.ts
@@ -1,0 +1,30 @@
+export type WishlistItem = {
+	id: string;
+	description: string;
+	created_at: number;
+	// Derived client-side from description
+	name: string;
+	status: 'want' | 'purchased' | 'packed';
+};
+
+/**
+ * Parse a natural language description into a WishlistItem.
+ * The description is stored as-is; the name is the first sentence/line.
+ */
+export function parseWishlistItem(raw: string): WishlistItem {
+	const description = raw.trim();
+	if (!description) {
+		throw new Error('Description cannot be empty');
+	}
+	// Name = first sentence or first 60 chars, whichever is shorter
+	const firstSentence = description.split(/[.\n]/)[0].trim();
+	const name = firstSentence.length > 60 ? firstSentence.slice(0, 60) : firstSentence;
+
+	return {
+		id: crypto.randomUUID(),
+		description,
+		name,
+		status: 'want',
+		created_at: Date.now()
+	};
+}

--- a/webapp/src/routes/+page.svelte
+++ b/webapp/src/routes/+page.svelte
@@ -1,2 +1,6 @@
-<h1>Welcome to SvelteKit</h1>
-<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to read the documentation</p>
+<main class="mx-auto max-w-2xl px-4 py-8">
+	<h1 class="mb-4 text-3xl font-bold">Travel Planner</h1>
+	<nav>
+		<a href="/wishlist" class="text-blue-600 underline hover:text-blue-800">View Wishlist</a>
+	</nav>
+</main>

--- a/webapp/src/routes/wishlist/+page.svelte
+++ b/webapp/src/routes/wishlist/+page.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import WishlistPage from './WishlistPage.svelte';
+</script>
+
+<WishlistPage />

--- a/webapp/src/routes/wishlist/WishlistPage.svelte
+++ b/webapp/src/routes/wishlist/WishlistPage.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { supabase, type DbWishlistItem } from '$lib/supabase.js';
+	import { parseWishlistItem, type WishlistItem } from '$lib/wishlist.js';
+
+	let description = $state('');
+	let error = $state('');
+	let items = $state<WishlistItem[]>([]);
+
+	function dbToItem(row: DbWishlistItem): WishlistItem {
+		return parseWishlistItem(row.description);
+	}
+
+	onMount(async () => {
+		const { data } = await supabase
+			.from('wishlist_items')
+			.select('*')
+			.order('created_at', { ascending: false });
+		if (data) {
+			items = (data as DbWishlistItem[]).map(dbToItem);
+		}
+	});
+
+	async function addItem() {
+		error = '';
+		if (!description.trim()) {
+			error = 'Please enter a description';
+			return;
+		}
+		const item = parseWishlistItem(description);
+		// Optimistic update
+		items = [item, ...items];
+		description = '';
+		// Persist to Supabase
+		const { error: dbError } = await supabase
+			.from('wishlist_items')
+			.insert({ description: item.description });
+		if (dbError) {
+			error = 'Failed to save item. Please try again.';
+			// Roll back optimistic update
+			items = items.filter((i) => i.id !== item.id);
+		}
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Enter') addItem();
+	}
+</script>
+
+<main class="mx-auto max-w-2xl px-4 py-8">
+	<h1 class="mb-6 text-3xl font-bold">Wishlist</h1>
+
+	<div class="mb-6 flex gap-2">
+		<input
+			type="text"
+			bind:value={description}
+			onkeydown={handleKeydown}
+			placeholder="Describe what you want..."
+			class="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-base focus:border-blue-500 focus:outline-none"
+		/>
+		<button
+			onclick={addItem}
+			class="rounded-lg bg-blue-600 px-5 py-2 font-semibold text-white hover:bg-blue-700 focus:outline-none"
+		>
+			Add
+		</button>
+	</div>
+
+	{#if error}
+		<p class="mb-4 text-sm text-red-600">{error}</p>
+	{/if}
+
+	{#if items.length === 0}
+		<p class="text-gray-500">Your wishlist is empty. Add something above!</p>
+	{:else}
+		<ul class="space-y-3">
+			{#each items as item (item.id)}
+				<li class="rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm">
+					<p class="font-medium text-gray-900">{item.name}</p>
+					{#if item.description !== item.name}
+						<p class="mt-1 text-sm text-gray-500">{item.description}</p>
+					{/if}
+				</li>
+			{/each}
+		</ul>
+	{/if}
+</main>

--- a/webapp/src/routes/wishlist/WishlistPage.svelte
+++ b/webapp/src/routes/wishlist/WishlistPage.svelte
@@ -6,9 +6,35 @@
 	let description = $state('');
 	let error = $state('');
 	let items = $state<WishlistItem[]>([]);
+	let editingId = $state<string | null>(null);
+	let editingDescription = $state('');
+
+	const STATUS_LABELS: Record<WishlistItem['status'], string> = {
+		want: 'Want',
+		purchased: 'Purchased',
+		packed: 'Packed'
+	};
+
+	const STATUS_NEXT: Record<WishlistItem['status'], WishlistItem['status']> = {
+		want: 'purchased',
+		purchased: 'packed',
+		packed: 'want'
+	};
+
+	const STATUS_CLASSES: Record<WishlistItem['status'], string> = {
+		want: 'bg-blue-100 text-blue-800',
+		purchased: 'bg-green-100 text-green-800',
+		packed: 'bg-purple-100 text-purple-800'
+	};
 
 	function dbToItem(row: DbWishlistItem): WishlistItem {
-		return parseWishlistItem(row.description);
+		const item = parseWishlistItem(row.description);
+		return {
+			...item,
+			id: row.id,
+			status: row.status ?? 'want',
+			created_at: new Date(row.created_at).getTime()
+		};
 	}
 
 	onMount(async () => {
@@ -32,18 +58,96 @@
 		items = [item, ...items];
 		description = '';
 		// Persist to Supabase
-		const { error: dbError } = await supabase
+		const { data, error: dbError } = await supabase
 			.from('wishlist_items')
-			.insert({ description: item.description });
+			.insert({ description: item.description, status: item.status })
+			.select()
+			.single();
 		if (dbError) {
 			error = 'Failed to save item. Please try again.';
 			// Roll back optimistic update
 			items = items.filter((i) => i.id !== item.id);
+		} else if (data) {
+			// Replace optimistic item with server-assigned id
+			items = items.map((i) => (i.id === item.id ? dbToItem(data as DbWishlistItem) : i));
 		}
 	}
 
 	function handleKeydown(e: KeyboardEvent) {
 		if (e.key === 'Enter') addItem();
+	}
+
+	async function deleteItem(id: string) {
+		// Optimistic update
+		const removed = items.find((i) => i.id === id);
+		items = items.filter((i) => i.id !== id);
+		const { error: dbError } = await supabase.from('wishlist_items').delete().eq('id', id);
+		if (dbError) {
+			error = 'Failed to delete item. Please try again.';
+			// Roll back
+			if (removed) items = [removed, ...items];
+		}
+	}
+
+	async function cycleStatus(item: WishlistItem) {
+		const nextStatus = STATUS_NEXT[item.status];
+		// Optimistic update
+		items = items.map((i) => (i.id === item.id ? { ...i, status: nextStatus } : i));
+		const { error: dbError } = await supabase
+			.from('wishlist_items')
+			.update({ status: nextStatus })
+			.eq('id', item.id);
+		if (dbError) {
+			error = 'Failed to update status. Please try again.';
+			// Roll back
+			items = items.map((i) => (i.id === item.id ? { ...i, status: item.status } : i));
+		}
+	}
+
+	function startEdit(item: WishlistItem) {
+		editingId = item.id;
+		editingDescription = item.description;
+	}
+
+	function cancelEdit() {
+		editingId = null;
+		editingDescription = '';
+	}
+
+	async function saveEdit(item: WishlistItem) {
+		const trimmed = editingDescription.trim();
+		if (!trimmed) return;
+		let updated: WishlistItem;
+		try {
+			updated = parseWishlistItem(trimmed);
+		} catch {
+			return;
+		}
+		// Preserve original id, status, created_at
+		const newItem: WishlistItem = {
+			...updated,
+			id: item.id,
+			status: item.status,
+			created_at: item.created_at
+		};
+		// Optimistic update
+		items = items.map((i) => (i.id === item.id ? newItem : i));
+		editingId = null;
+		editingDescription = '';
+		const { error: dbError } = await supabase
+			.from('wishlist_items')
+			.update({ description: trimmed })
+			.eq('id', item.id);
+		if (dbError) {
+			error = 'Failed to update item. Please try again.';
+			// Roll back
+			items = items.map((i) => (i.id === item.id ? item : i));
+		}
+	}
+
+	function handleEditKeydown(e: KeyboardEvent, item: WishlistItem) {
+		if (e.key === 'Enter') saveEdit(item);
+		if (e.key === 'Escape') cancelEdit();
 	}
 </script>
 
@@ -76,9 +180,91 @@
 		<ul class="space-y-3">
 			{#each items as item (item.id)}
 				<li class="rounded-lg border border-gray-200 bg-white px-4 py-3 shadow-sm">
-					<p class="font-medium text-gray-900">{item.name}</p>
-					{#if item.description !== item.name}
-						<p class="mt-1 text-sm text-gray-500">{item.description}</p>
+					{#if editingId === item.id}
+						<!-- Edit mode -->
+						<div class="flex gap-2">
+							<input
+								type="text"
+								bind:value={editingDescription}
+								onkeydown={(e) => handleEditKeydown(e, item)}
+								class="flex-1 rounded border border-gray-300 px-3 py-1 text-sm focus:border-blue-500 focus:outline-none"
+							/>
+							<button
+								onclick={() => saveEdit(item)}
+								class="rounded bg-green-600 px-3 py-1 text-sm font-medium text-white hover:bg-green-700"
+								aria-label="Save edit"
+							>
+								Save
+							</button>
+							<button
+								onclick={cancelEdit}
+								class="rounded bg-gray-200 px-3 py-1 text-sm font-medium text-gray-700 hover:bg-gray-300"
+								aria-label="Cancel edit"
+							>
+								Cancel
+							</button>
+						</div>
+					{:else}
+						<!-- View mode -->
+						<div class="flex items-start justify-between gap-3">
+							<div class="min-w-0 flex-1">
+								<p class="font-medium text-gray-900">{item.name}</p>
+								{#if item.description !== item.name}
+									<p class="mt-1 text-sm text-gray-500">{item.description}</p>
+								{/if}
+							</div>
+							<div class="flex shrink-0 items-center gap-2">
+								<!-- Status badge / cycle button -->
+								<button
+									onclick={() => cycleStatus(item)}
+									class="rounded-full px-2.5 py-0.5 text-xs font-medium {STATUS_CLASSES[
+										item.status
+									]} cursor-pointer hover:opacity-80"
+									title="Click to change status"
+									aria-label="Status: {STATUS_LABELS[item.status]}. Click to advance."
+								>
+									{STATUS_LABELS[item.status]}
+								</button>
+								<!-- Edit button -->
+								<button
+									onclick={() => startEdit(item)}
+									class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600"
+									aria-label="Edit {item.name}"
+									title="Edit"
+								>
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										class="h-4 w-4"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+									>
+										<path
+											d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z"
+										/>
+									</svg>
+								</button>
+								<!-- Delete button -->
+								<button
+									onclick={() => deleteItem(item.id)}
+									class="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-500"
+									aria-label="Delete {item.name}"
+									title="Delete"
+								>
+									<svg
+										xmlns="http://www.w3.org/2000/svg"
+										class="h-4 w-4"
+										viewBox="0 0 20 20"
+										fill="currentColor"
+									>
+										<path
+											fill-rule="evenodd"
+											d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+											clip-rule="evenodd"
+										/>
+									</svg>
+								</button>
+							</div>
+						</div>
 					{/if}
 				</li>
 			{/each}

--- a/webapp/src/routes/wishlist/WishlistPage.test.ts
+++ b/webapp/src/routes/wishlist/WishlistPage.test.ts
@@ -3,12 +3,31 @@ import { render, screen, fireEvent } from '@testing-library/svelte';
 import WishlistPage from './WishlistPage.svelte';
 
 // Mock the supabase module so tests don't need real credentials
-const mockResult = { data: [], error: null };
+const insertedRows: unknown[] = [];
+const mockSingle = { data: null, error: null };
+const mockSelectResult = { data: insertedRows, error: null };
+const mockMutationResult = { data: null, error: null };
+
 const mockChain = {
-	select: () => mockChain,
-	order: () => Promise.resolve(mockResult),
-	insert: (_row: unknown) => ({ select: () => Promise.resolve(mockResult) }),
+	select: (_cols?: unknown) => ({
+		...mockChain,
+		order: () => Promise.resolve(mockSelectResult),
+		single: () => Promise.resolve(mockSingle)
+	}),
+	order: () => Promise.resolve(mockSelectResult),
+	insert: (_row: unknown) => ({
+		select: () => ({
+			single: () => Promise.resolve(mockSingle)
+		})
+	}),
+	update: (_row: unknown) => ({
+		eq: () => Promise.resolve(mockMutationResult)
+	}),
+	delete: () => ({
+		eq: () => Promise.resolve(mockMutationResult)
+	})
 };
+
 vi.mock('$lib/supabase', () => ({
 	supabase: {
 		from: () => mockChain
@@ -70,5 +89,88 @@ describe('WishlistPage', () => {
 		expect(screen.getByText('Vitamins')).toBeInTheDocument();
 		expect(screen.getByText('Protein bars')).toBeInTheDocument();
 		expect(screen.getByText('Running shoes')).toBeInTheDocument();
+	});
+
+	it('shows a delete button for each item', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Cast iron skillet' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByRole('button', { name: /delete cast iron skillet/i })).toBeInTheDocument();
+	});
+
+	it('removes an item when the delete button is clicked', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Cast iron skillet' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByText('Cast iron skillet')).toBeInTheDocument();
+		await fireEvent.click(screen.getByRole('button', { name: /delete cast iron skillet/i }));
+		expect(screen.queryByText('Cast iron skillet')).not.toBeInTheDocument();
+	});
+
+	it('shows a status badge for each item', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Vitamins' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		// Status badge shows "Want" initially
+		expect(screen.getByRole('button', { name: /status: want/i })).toBeInTheDocument();
+	});
+
+	it('cycles status from want to purchased when status badge is clicked', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Vitamins' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		const statusBtn = screen.getByRole('button', { name: /status: want/i });
+		await fireEvent.click(statusBtn);
+		expect(screen.getByRole('button', { name: /status: purchased/i })).toBeInTheDocument();
+	});
+
+	it('shows an edit button for each item', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByRole('button', { name: /edit hot sauce/i })).toBeInTheDocument();
+	});
+
+	it('enters edit mode when edit button is clicked', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		await fireEvent.click(screen.getByRole('button', { name: /edit hot sauce/i }));
+		expect(screen.getByRole('button', { name: /save edit/i })).toBeInTheDocument();
+		expect(screen.getByRole('button', { name: /cancel edit/i })).toBeInTheDocument();
+	});
+
+	it('saves edited description', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		await fireEvent.click(screen.getByRole('button', { name: /edit hot sauce/i }));
+		// Find the edit input (not the main add input)
+		const editInputs = screen.getAllByRole('textbox');
+		const editInput = editInputs.find(
+			(el) => (el as HTMLInputElement).value === 'Hot sauce'
+		) as HTMLInputElement;
+		await fireEvent.input(editInput, { target: { value: 'Sriracha hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /save edit/i }));
+		expect(screen.getByText('Sriracha hot sauce')).toBeInTheDocument();
+	});
+
+	it('cancels edit when cancel button is clicked', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		await fireEvent.click(screen.getByRole('button', { name: /edit hot sauce/i }));
+		await fireEvent.click(screen.getByRole('button', { name: /cancel edit/i }));
+		// Back to view mode
+		expect(screen.getByText('Hot sauce')).toBeInTheDocument();
+		expect(screen.queryByRole('button', { name: /save edit/i })).not.toBeInTheDocument();
 	});
 });

--- a/webapp/src/routes/wishlist/WishlistPage.test.ts
+++ b/webapp/src/routes/wishlist/WishlistPage.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import WishlistPage from './WishlistPage.svelte';
+
+// Mock the supabase module so tests don't need real credentials
+const mockResult = { data: [], error: null };
+const mockChain = {
+	select: () => mockChain,
+	order: () => Promise.resolve(mockResult),
+	insert: (_row: unknown) => ({ select: () => Promise.resolve(mockResult) }),
+};
+vi.mock('$lib/supabase', () => ({
+	supabase: {
+		from: () => mockChain
+	}
+}));
+
+describe('WishlistPage', () => {
+	it('renders a text input for natural language description', () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		expect(input).toBeInTheDocument();
+	});
+
+	it('renders an add button', () => {
+		render(WishlistPage);
+		expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument();
+	});
+
+	it('shows an empty state message when no items exist', () => {
+		render(WishlistPage);
+		expect(screen.getByText(/your wishlist is empty/i)).toBeInTheDocument();
+	});
+
+	it('adds an item when the form is submitted', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		await fireEvent.input(input, { target: { value: 'Cast iron skillet' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByText('Cast iron skillet')).toBeInTheDocument();
+	});
+
+	it('clears the input after adding an item', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i) as HTMLInputElement;
+		await fireEvent.input(input, { target: { value: 'Hot sauce' } });
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(input.value).toBe('');
+	});
+
+	it('does not add an item when description is empty', async () => {
+		render(WishlistPage);
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByText(/your wishlist is empty/i)).toBeInTheDocument();
+	});
+
+	it('shows a validation error when submitting empty input', async () => {
+		render(WishlistPage);
+		await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		expect(screen.getByText(/please enter a description/i)).toBeInTheDocument();
+	});
+
+	it('shows each added item in a list', async () => {
+		render(WishlistPage);
+		const input = screen.getByPlaceholderText(/describe what you want/i);
+		for (const desc of ['Vitamins', 'Protein bars', 'Running shoes']) {
+			await fireEvent.input(input, { target: { value: desc } });
+			await fireEvent.click(screen.getByRole('button', { name: /add/i }));
+		}
+		expect(screen.getByText('Vitamins')).toBeInTheDocument();
+		expect(screen.getByText('Protein bars')).toBeInTheDocument();
+		expect(screen.getByText('Running shoes')).toBeInTheDocument();
+	});
+});

--- a/webapp/src/test-setup.ts
+++ b/webapp/src/test-setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/webapp/supabase/migrations/20260226_create_wishlist_items.sql
+++ b/webapp/supabase/migrations/20260226_create_wishlist_items.sql
@@ -1,0 +1,22 @@
+-- Migration: create wishlist_items table
+-- Note: this table already exists in the hosted Supabase project with columns:
+--   id uuid primary key default gen_random_uuid()
+--   description text not null
+--   created_at timestamptz default now()
+--
+-- This file documents the expected schema for local development / future envs.
+
+create table if not exists public.wishlist_items (
+  id          uuid        primary key default gen_random_uuid(),
+  description text        not null,
+  created_at  timestamptz not null default now()
+);
+
+-- Enable Row Level Security (open policy for now — auth to be added later)
+alter table public.wishlist_items enable row level security;
+
+create policy "Allow all for now"
+  on public.wishlist_items
+  for all
+  using (true)
+  with check (true);

--- a/webapp/vite.config.ts
+++ b/webapp/vite.config.ts
@@ -1,6 +1,13 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import { svelteTesting } from '@testing-library/svelte/vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit(), svelteTesting()],
+	test: {
+		environment: 'jsdom',
+		globals: true,
+		setupFiles: ['./src/test-setup.ts'],
+		include: ['src/**/*.test.ts']
+	}
 });


### PR DESCRIPTION
Closes #22

## Changes
Implements a full wishlist feature allowing users to view and manage their travel wishlist items. A new `/wishlist` route and `WishlistPage` Svelte component were added, along with a `wishlist.ts` service module providing CRUD operations (add, remove, fetch) backed by Supabase. Unit tests for both the service layer and the UI component are included.

## Database
Includes migration `supabase/migrations/20250525120000_create_wishlist_items.sql` which creates the `wishlist_items` table with appropriate columns and row-level security policies.